### PR TITLE
change prettier printWidth to 80 (recommended)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 100,
+  "printWidth": 80,
   "proseWrap": "always",
   "singleQuote": true
 }


### PR DESCRIPTION
Change value from 100 to 80 to improve readability. Recommended by prettier - see here for reference https://prettier.io/docs/en/options.html#print-width